### PR TITLE
Add clean city event pages

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,56 @@
+# PR: Add Clean City Event Pages With Per-City Data
+
+Target branch: `main`
+
+## Summary
+
+This PR adds clean city-specific event pages for WWDC Watch Party Around India and moves city event content into structured, per-city TypeScript data files. Each city now owns its own agenda, Luma registration link, venue details, sponsor details, and Event schema data.
+
+## What Changed
+
+- Added clean city routes like `/hyderabad`, `/delhi`, `/bangalore`, `/mumbai`, `/ahmedabad`, `/surat`, `/chennai`, and `/kozhikode`.
+- Added a reusable city event page for city-specific landing pages.
+- Added per-city event data files under `src/data/city-events/`.
+- Kept a stable city data export through `src/data/city-events.ts`.
+- Added city-specific agendas so each city can have a different schedule.
+- Added Event structured data JSON-LD for city pages.
+- Updated homepage registration cards to route to the clean city pages.
+- Fixed city page Register buttons so both links open the correct Luma event page for the active city.
+- Added GitHub Pages fallback handling for clean browser routes.
+- Added project README documentation for updating city pages, agendas, Luma links, and schema fields.
+
+## City Data Structure
+
+Each city has its own file:
+
+- `src/data/city-events/ahmedabad.ts`
+- `src/data/city-events/bangalore.ts`
+- `src/data/city-events/chennai.ts`
+- `src/data/city-events/delhi.ts`
+- `src/data/city-events/hyderabad.ts`
+- `src/data/city-events/kozhikode.ts`
+- `src/data/city-events/mumbai.ts`
+- `src/data/city-events/surat.ts`
+
+The root `src/data/city-events.ts` file imports these city blocks and exports `cityEvents` plus `getCityEventBySlug`.
+
+## Notes
+
+- Luma is linked directly instead of embedded because Luma event pages block iframe rendering with frame protection headers.
+- `/hyderbad` is supported as an alias and redirects to `/hyderabad`.
+- Structured data follows Google's Event schema guidance and is generated from the same city data used by the UI.
+
+## Testing
+
+- `npm run lint`
+- `npm run build`
+- Verified `/hyderabad`, `/chennai`, `/delhi`, `/kozhikode`, and `/hyderbad` with headless Chrome.
+- Verified Hyderabad renders Event JSON-LD.
+- Verified both Hyderabad Register buttons point to `https://lu.ma/jehijqln`.
+
+## Review Checklist
+
+- Confirm each city has the correct Luma URL.
+- Confirm each city agenda is final or marked for organizer review.
+- Confirm venue addresses and schema dates are accurate.
+- Confirm clean URLs work after deployment to GitHub Pages.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,168 @@
-# React + TypeScript + Vite
+# Watch Party Around India
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Website for WWDC Watch Party Around India, built with React, TypeScript, Vite, and Tailwind CSS.
 
-Currently, two official plugins are available:
+The site has a main landing page plus clean city URLs such as:
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- `/hyderabad`
+- `/delhi`
+- `/bangalore`
+- `/mumbai`
+- `/ahmedabad`
+- `/surat`
+- `/chennai`
+- `/kozhikode`
 
-## Expanding the ESLint configuration
+## Getting Started
 
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
+Install dependencies:
 
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default {
-  // other rules...
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: ['./tsconfig.json', './tsconfig.node.json'],
-    tsconfigRootDir: __dirname,
-  },
-}
+```sh
+npm install
 ```
 
-- Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
-- Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+Run the local dev server:
+
+```sh
+npm run dev
+```
+
+Build for production:
+
+```sh
+npm run build
+```
+
+Run lint checks:
+
+```sh
+npm run lint
+```
+
+## City Pages
+
+Each city page is powered by data in `src/data/city-events/`.
+
+The root export is `src/data/city-events.ts`. Keep importing from this file in components:
+
+```ts
+import { cityEvents, getCityEventBySlug } from "../data/city-events";
+```
+
+Do not import city files directly from UI components unless there is a strong reason. The aggregator keeps the public API stable.
+
+## Where To Update A City
+
+Edit the matching city file:
+
+- `src/data/city-events/ahmedabad.ts`
+- `src/data/city-events/bangalore.ts`
+- `src/data/city-events/chennai.ts`
+- `src/data/city-events/delhi.ts`
+- `src/data/city-events/hyderabad.ts`
+- `src/data/city-events/kozhikode.ts`
+- `src/data/city-events/mumbai.ts`
+- `src/data/city-events/surat.ts`
+
+Each file exports one `CityEvent` object. This controls the city page, home registration card, Luma registration links, and structured data.
+
+Common fields to update:
+
+- `slug`: clean URL path, for example `hyderabad` creates `/hyderabad`.
+- `aliases`: alternate spellings that should redirect to the canonical slug, for example `hyderbad`.
+- `city` and `chapterName`: page title and organizer display text.
+- `date`, `time`, `startDate`, `endDate`: visible time and Event schema dates.
+- `venue`, `address`, `structuredAddress`, `location`, `mapUrl`: location card and structured data.
+- `lumaUrl`: used by both Register buttons and Event schema offer URL.
+- `sponsorName` and `sponsorLogo`: venue partner block.
+- `gradient`: city card/page accent colors.
+- `highlights`: short badges below the hero copy.
+- `agenda`: city-specific schedule shown in the "What to expect" section.
+
+Use ISO 8601 dates with the India timezone offset for schema fields:
+
+```ts
+startDate: "2025-06-09T19:00:00+05:30",
+endDate: "2025-06-10T00:30:00+05:30",
+```
+
+## Updating A City Agenda
+
+Agendas are intentionally city-specific. Update the `agenda` array inside the relevant city file:
+
+```ts
+agenda: [
+  {
+    time: "7:00 PM",
+    title: "Doors open",
+    description: "Check in and meet the local community.",
+  },
+  {
+    time: "10:30 PM",
+    title: "WWDC keynote watch",
+    description: "Watch the keynote live with the city chapter.",
+  },
+],
+```
+
+The page renders agenda items automatically from this array.
+
+## Adding A New City
+
+1. Add organizer and sponsor assets under `src/assets/2025/` if needed.
+2. Create a new file in `src/data/city-events/<city>.ts`.
+3. Export a `CityEvent` object from that file.
+4. Import the new city event in `src/data/city-events.ts`.
+5. Add it to the `cityEvents` array.
+6. Add aliases if old links or common misspellings should redirect.
+7. Run `npm run lint` and `npm run build`.
+
+The clean URL is handled by the router route `/:citySlug` in `src/main.tsx`.
+
+## Luma Registration
+
+Luma pages are linked directly through `lumaUrl`. The city page has two registration links:
+
+- Top-right `Register`
+- Card button `Register on Luma`
+
+Both buttons use the city-specific `lumaUrl`.
+
+Luma event pages are not embedded in an iframe because Luma blocks iframe rendering with frame protection headers. Keep registration as a direct link unless Luma changes that behavior.
+
+## Structured Data
+
+Event JSON-LD is generated in `src/components/event-structured-data.tsx` from each `CityEvent`.
+
+When changing event details, make sure these fields are accurate:
+
+- `startDate`
+- `endDate`
+- `venue`
+- `structuredAddress`
+- `lumaUrl`
+- `description`
+- `chapterName`
+
+Google's Event structured data documentation is here:
+
+https://developers.google.com/search/docs/appearance/structured-data/event
+
+## Routing And GitHub Pages
+
+The app uses browser routes for clean URLs. GitHub Pages needs a fallback so direct visits to `/hyderabad` still load the React app.
+
+Relevant files:
+
+- `src/main.tsx`: app routes.
+- `public/404.html`: GitHub Pages fallback redirect.
+- `index.html`: restores clean paths from the fallback redirect.
+- `public/CNAME`: custom domain config.
+
+## Important Components
+
+- `src/components/register-now.tsx`: city cards on the homepage.
+- `src/components/city-event-page.tsx`: city page layout and Register buttons.
+- `src/components/event-structured-data.tsx`: Event schema JSON-LD.
+- `src/data/city-events.ts`: public city event list and slug lookup.
+- `src/data/city-events/types.ts`: shared city data types.

--- a/index.html
+++ b/index.html
@@ -2,6 +2,25 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <script>
+      (function (location) {
+        if (location.search[1] === "/") {
+          var decoded = location.search
+            .slice(1)
+            .split("&")
+            .map(function (segment) {
+              return segment.replace(/~and~/g, "&");
+            })
+            .join("?");
+
+          window.history.replaceState(
+            null,
+            null,
+            location.pathname.slice(0, -1) + decoded + location.hash
+          );
+        }
+      })(window.location);
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <title>WWDC25 - Watch Party Around India</title>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script>
+      (function (location) {
+        var path = location.pathname.slice(1);
+        var query = location.search
+          ? "&" + location.search.slice(1).replace(/&/g, "~and~")
+          : "";
+
+        location.replace(
+          location.protocol +
+            "//" +
+            location.hostname +
+            (location.port ? ":" + location.port : "") +
+            "/?/" +
+            path +
+            query +
+            location.hash
+        );
+      })(window.location);
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+watchpartyaroundindia.com

--- a/src/components/city-event-page.tsx
+++ b/src/components/city-event-page.tsx
@@ -1,0 +1,199 @@
+import type { CSSProperties } from "react";
+import { Link, Navigate, useParams } from "react-router-dom";
+import { HashLink } from "react-router-hash-link";
+import wwdcLogo from "../assets/2025/logo.svg";
+import locationPinLogo from "../assets/2025/location-pin.svg";
+import { getCityEventBySlug } from "../data/city-events";
+import type { CityEvent } from "../data/city-events";
+import EventStructuredData from "./event-structured-data";
+
+const gradientStyle = (event: CityEvent): CSSProperties => ({
+  backgroundImage: `linear-gradient(180deg, ${event.gradient.from} 0%, ${event.gradient.to} 100%)`,
+});
+
+const CityEventPage = () => {
+  const { citySlug } = useParams();
+  const event = getCityEventBySlug(citySlug);
+
+  if (!event) {
+    return <Navigate to="/" replace />;
+  }
+
+  if (citySlug?.toLowerCase() !== event.slug) {
+    return <Navigate to={`/${event.slug}`} replace />;
+  }
+
+  return (
+    <div className="min-h-screen overflow-x-hidden bg-white bg-[radial-gradient(#ccc_1px,transparent_1px)] bg-[length:20px_20px] font-sans text-[#1F1F29]">
+      <EventStructuredData event={event} />
+      <header className="flex items-center justify-between max-w-6xl mx-auto px-4 md:px-8 py-8 font-prompt">
+        <Link to="/" aria-label="Watch Party Around India home">
+          <img
+            src={wwdcLogo}
+            alt="WWDC 2025 logo"
+            className="w-24 h-9 md:w-32 md:h-11 object-contain"
+          />
+        </Link>
+        <div className="flex items-center gap-3">
+          <HashLink
+            to="/#register"
+            className="hidden sm:inline-flex font-medium text-sm md:text-base hover:underline hover:decoration-[#FFC9F0] hover:[text-decoration-thickness:4px]"
+          >
+            All cities
+          </HashLink>
+          <a
+            href={event.lumaUrl}
+            className="text-sm md:text-base text-white bg-[#4884FF] font-medium px-4 md:px-6 py-2 border-2 border-[#0B2131] shadow-[-3px_3px_0_1px_#0B2131] hover:bg-[#366fd1] transition-colors duration-200"
+          >
+            Register
+          </a>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 md:px-8 pb-24 overflow-x-hidden">
+        <div className="grid lg:grid-cols-[1fr_380px] gap-8 lg:gap-12 items-start min-w-0">
+          <section className="pt-4 md:pt-10 min-w-0">
+            <p className="font-oliver uppercase text-xl md:text-2xl text-[#4B2828] mb-4">
+              Watch Party Around India
+            </p>
+            <h1 className="font-black text-5xl md:text-7xl lg:text-7xl leading-none text-[#1F1F29] break-words">
+              WWDC25 in {event.city}
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg md:text-xl text-black/70 break-words">
+              {event.description}
+            </p>
+
+            <div className="mt-8 flex flex-wrap gap-3">
+              {event.highlights.map((highlight) => (
+                <span
+                  key={highlight}
+                  className="max-w-full break-words bg-white border-2 border-[#0B2131] shadow-[-2px_2px_0_0_#0B2131] px-4 py-2 text-sm font-semibold"
+                >
+                  {highlight}
+                </span>
+              ))}
+            </div>
+
+            <div className="mt-12 grid md:grid-cols-2 gap-5 min-w-0">
+              <div className="min-w-0 bg-white border-2 border-[#0B2131] p-5 shadow-[-4px_4px_0_0_#0B2131]">
+                <p className="text-sm font-bold text-black/45 uppercase">
+                  Date and time
+                </p>
+                <p className="mt-2 text-2xl font-bold">{event.date}</p>
+                <p className="text-lg font-semibold text-black/65">
+                  {event.time} IST
+                </p>
+              </div>
+              <a
+                href={event.mapUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="min-w-0 bg-white border-2 border-[#0B2131] p-5 shadow-[-4px_4px_0_0_#0B2131] hover:bg-[#f6f6f6] transition-colors"
+              >
+                <p className="text-sm font-bold text-black/45 uppercase">
+                  Location
+                </p>
+                <p className="mt-2 text-2xl font-bold">{event.location}</p>
+                <p className="text-lg font-semibold text-black/65 break-words">
+                  {event.venue}
+                </p>
+              </a>
+            </div>
+
+            <section className="mt-14" aria-labelledby="event-agenda-heading">
+              <h2
+                id="event-agenda-heading"
+                className="font-bold text-3xl md:text-4xl"
+              >
+                What to expect
+              </h2>
+              <div className="mt-6 flex flex-col gap-4">
+                {event.agenda.map((item) => (
+                  <div
+                    key={`${item.time}-${item.title}`}
+                    className="grid sm:grid-cols-[140px_1fr] gap-3 min-w-0 bg-white/80 border-l-4 border-[#4884FF] p-4"
+                  >
+                    <p className="font-bold text-[#4884FF]">{item.time}</p>
+                    <div>
+                      <h3 className="font-bold text-xl">{item.title}</h3>
+                      <p className="text-black/65">{item.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </section>
+
+          <aside className="min-w-0 w-full lg:sticky lg:top-8">
+            <div
+              className="rounded-3xl border-2 border-[#0B2131] shadow-[-6px_6px_0_0_#0B2131] overflow-hidden bg-white"
+              aria-label={`${event.city} event registration card`}
+            >
+              <div
+                className="min-h-56 p-6 flex flex-col justify-between text-white"
+                style={gradientStyle(event)}
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <img
+                    src={event.logo}
+                    alt={`${event.chapterName} logo`}
+                    className="w-14 h-14 rounded-full object-cover bg-white"
+                  />
+                  <span className="bg-black/80 px-3 py-1 rounded-md text-sm font-semibold">
+                    {event.time}
+                  </span>
+                </div>
+                <div>
+                  <p className="font-semibold text-white/80">
+                    {event.chapterName}
+                  </p>
+                  <h2 className="mt-1 text-3xl font-black">
+                    {event.city} Watch Party
+                  </h2>
+                </div>
+              </div>
+
+              <div className="p-6">
+                <div className="flex items-start gap-3">
+                  <img
+                    src={locationPinLogo}
+                    alt=""
+                    aria-hidden="true"
+                    className="w-5 h-5 mt-1"
+                  />
+                  <div>
+                    <p className="font-bold">{event.venue}</p>
+                    <p className="text-sm text-black/60">{event.address}</p>
+                  </div>
+                </div>
+
+                <a
+                  href={event.lumaUrl}
+                  className="mt-6 flex items-center justify-center w-full rounded-lg bg-[#2A282F] text-white font-bold py-3 hover:bg-black transition-colors"
+                >
+                  Register on Luma
+                </a>
+
+                <div className="mt-6 border-t border-black/10 pt-5">
+                  <p className="text-sm font-bold text-black/45 uppercase">
+                    Venue partner
+                  </p>
+                  <div className="mt-3 flex items-center gap-3">
+                    <img
+                      src={event.sponsorLogo}
+                      alt={`${event.sponsorName} logo`}
+                      className="h-10 w-auto rounded bg-white object-contain"
+                    />
+                    <p className="font-bold">{event.sponsorName}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default CityEventPage;

--- a/src/components/event-structured-data.tsx
+++ b/src/components/event-structured-data.tsx
@@ -1,0 +1,60 @@
+import heroImage from "../assets/2025/hero.svg";
+import type { CityEvent } from "../data/city-events";
+
+const SITE_URL = "https://watchpartyaroundindia.com";
+
+const absoluteUrl = (path: string) => new URL(path, SITE_URL).href;
+
+interface EventStructuredDataProps {
+  event: CityEvent;
+}
+
+const EventStructuredData = ({ event }: EventStructuredDataProps) => {
+  const eventUrl = absoluteUrl(`/${event.slug}`);
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    name: `WWDC25 Watch Party Around India: ${event.city}`,
+    description: event.description,
+    startDate: event.startDate,
+    endDate: event.endDate,
+    eventStatus: "https://schema.org/EventScheduled",
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    url: eventUrl,
+    image: [absoluteUrl(heroImage)],
+    location: {
+      "@type": "Place",
+      name: event.venue,
+      address: {
+        "@type": "PostalAddress",
+        streetAddress: event.structuredAddress.streetAddress,
+        addressLocality: event.structuredAddress.addressLocality,
+        addressRegion: event.structuredAddress.addressRegion,
+        addressCountry: event.structuredAddress.addressCountry,
+      },
+    },
+    offers: {
+      "@type": "Offer",
+      url: event.lumaUrl,
+      price: 0,
+      priceCurrency: "INR",
+      availability: "https://schema.org/InStock",
+      validFrom: "2025-05-01T00:00:00+05:30",
+    },
+    organizer: {
+      "@type": "Organization",
+      name: event.chapterName,
+      url: SITE_URL,
+    },
+    isAccessibleForFree: true,
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+};
+
+export default EventStructuredData;

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -6,10 +6,10 @@ const Navbar = () => {
   const [menuOpen, setMenuOpen] = useState(false);
 
   const navItems = [
-    { id: 1, label: "About", section: "#" },
-    { id: 2, label: "Sponsors", section: "#sponsors" },
-    { id: 3, label: "Speakers", section: "#speakers" },
-    { id: 4, label: "2024", link: "/#2024" },
+    { id: 1, label: "About", section: "/" },
+    { id: 2, label: "Sponsors", section: "/#sponsors" },
+    { id: 3, label: "Speakers", section: "/#speakers" },
+    { id: 4, label: "2024", section: "/2024" },
   ];
 
   useEffect(() => {
@@ -30,7 +30,7 @@ const Navbar = () => {
   return (
     <nav className="relative w-full font-prompt">
       <div className="flex items-center w-full px-2 md:px-4 lg:px-8 py-10">
-        <Link to="#">
+        <Link to="/">
           <img
             src={wwdcLogo}
             alt="WWDC 2025 logo"
@@ -40,26 +40,17 @@ const Navbar = () => {
         <ul className="items-center justify-end flex-1 space-x-8 hidden md:flex mr-8">
           {navItems.map((item) => (
             <li key={item.id}>
-              {item.section ? (
-                <Link
-                  to={item.section}
-                  className="hover:underline hover:decoration-[#FFC9F0] hover:underline-offset-1 hover:[text-decoration-thickness:5px] cursor-pointer text-xl lg:text-2xl"
-                >
-                  {item.label}
-                </Link>
-              ) : (
-                <a
-                  href={item.link}
-                  className="hover:underline hover:decoration-[#FFC9F0] hover:underline-offset-1 hover:[text-decoration-thickness:5px] cursor-pointer text-xl lg:text-2xl"
-                >
-                  {item.label}
-                </a>
-              )}
+              <Link
+                to={item.section}
+                className="hover:underline hover:decoration-[#FFC9F0] hover:underline-offset-1 hover:[text-decoration-thickness:5px] cursor-pointer text-xl lg:text-2xl"
+              >
+                {item.label}
+              </Link>
             </li>
           ))}
         </ul>
         <Link
-          to="#register"
+          to="/#register"
           className="ml-auto md:ml-0 text-lg md:text-xl lg:text-2xl text-white bg-[#4884FF] font-medium px-4 md:px-6 lg:px-8 py-1 md:py-1.5 lg:py-2 border-2 border-[#0B2131] hidden md:block hover:bg-[#366fd1] transition-colors duration-200 text-center"
         >
           Register
@@ -100,32 +91,22 @@ const Navbar = () => {
       >
         <img src={wwdcLogo} alt="WWDC 2025 logo" className="w-32 h-12" />
         {navItems.map((item) =>
-          item.section ? (
-            <Link
-              key={item.id}
-              to={item.section}
-              className="hover:underline hover:decoration-[#FFC9F0] hover:underline-offset-1 hover:[text-decoration-thickness:5px] cursor-pointer text-xl lg:text-2xl"
-              onClick={() => setMenuOpen(false)}
-            >
-              {item.label}
-            </Link>
-          ) : (
-            <a
-              key={item.id}
-              href={item.link}
-              className="hover:underline hover:decoration-[#FFC9F0] hover:underline-offset-1 hover:[text-decoration-thickness:5px] cursor-pointer text-xl lg:text-2xl"
-              onClick={() => setMenuOpen(false)}
-            >
-              {item.label}
-            </a>
-          )
+          <Link
+            key={item.id}
+            to={item.section}
+            className="hover:underline hover:decoration-[#FFC9F0] hover:underline-offset-1 hover:[text-decoration-thickness:5px] cursor-pointer text-xl lg:text-2xl"
+            onClick={() => setMenuOpen(false)}
+          >
+            {item.label}
+          </Link>
         )}
-        <button
-          type="button"
+        <Link
+          to="/#register"
+          onClick={() => setMenuOpen(false)}
           className="mt-4 text-xl text-white bg-[#4884FF] font-medium px-6 py-2 border-2 border-[#0B2131] hover:bg-[#366fd1] transition-colors duration-200"
         >
           Register
-        </button>
+        </Link>
       </div>
     </nav>
   );

--- a/src/components/register-now.tsx
+++ b/src/components/register-now.tsx
@@ -1,105 +1,8 @@
+import { Link } from "react-router-dom";
 import locationPinLogo from "../assets/2025/location-pin.svg";
-import swiftAhmedabadLogo from "../assets/2025/organisers/swift-ahmedabad.svg";
-import swiftBengaluruLogo from "../assets/2025/organisers/swift-bengaluru.png";
-import swiftChennaiLogo from "../assets/2025/organisers/swift-chennai.png";
-import swiftDelhiLogo from "../assets/2025/organisers/swift-delhi.jpeg";
-import swiftHyderabadLogo from "../assets/2025/organisers/swift-hyderabad.svg";
-import swiftKozhikodeLogo from "../assets/2025/organisers/swift-kozhikode.svg";
-import swiftMumbaiLogo from "../assets/2025/organisers/swift-mumbai.png";
-import swiftSuratLogo from "../assets/2025/organisers/swift-surat.jpeg";
+import { cityEvents } from "../data/city-events";
 
 const RegisterNow = () => {
-  const swiftEvents = [
-    {
-      id: 1,
-      time: "7:00 PM",
-      logo: swiftBengaluruLogo,
-      chapterName: "Swift Bengaluru",
-      venue: "Swiggy HO, Ground Floor, Embassy TechVillage",
-      location: "Varthur",
-      registerLink: "https://lu.ma/9mfibs65",
-      startColour: "#FFC677",
-      endColour: "#FF9500",
-    },
-    {
-      id: 2,
-      time: "7:30 PM",
-      logo: swiftMumbaiLogo,
-      chapterName: "Swift Mumbai",
-      venue: "BookMyShow Office, Empressa 14",
-      location: "Andheri East",
-      registerLink: "https://lu.ma/cbn8zy6m",
-      startColour: "#A8D7FF",
-      endColour: "#6171FF",
-    },
-    {
-      id: 3,
-      time: "9:00 PM",
-      logo: swiftAhmedabadLogo,
-      chapterName: "Swift Ahmedabad",
-      venue: "7Span, 201, Isquare Corporate Park",
-      location: "Sola",
-      registerLink: "https://lu.ma/kne1yfpm",
-      startColour: "#DE9CFF",
-      endColour: "#AF52DE",
-    },
-    {
-      id: 4,
-      time: "8:00 PM",
-      logo: swiftSuratLogo,
-      chapterName: "Swift Surat",
-      venue: "JBcodeapp, 536, 5, Square Point, M.V Circle",
-      location: "Dahin Nagar",
-      registerLink: "https://lu.ma/j41uncut",
-      startColour: "#BB5BF3",
-      endColour: "#6900EE",
-    },
-    {
-      id: 5,
-      time: "8:00 PM",
-      logo: swiftChennaiLogo,
-      chapterName: "Swift Chennai",
-      venue: "Kissflow, No. 5, Tower-B, 10th Floor",
-      location: "Perungudi",
-      registerLink: "https://lu.ma/9engu1qy",
-      startColour: "#A8D7FF",
-      endColour: "#6171FF",
-    },
-    {
-      id: 6,
-      time: "9:00 PM",
-      logo: swiftDelhiLogo,
-      chapterName: "Swift Delhi",
-      venue: "Ixigo Office, 2nd Floor, Veritas Building",
-      location: "Gurugram",
-      registerLink: "https://lu.ma/pry2tx7d",
-      startColour: "#A8D7FF",
-      endColour: "#6171FF",
-    },
-    {
-      id: 7,
-      time: "7:00 PM",
-      logo: swiftHyderabadLogo,
-      chapterName: "Swift Hyderabad",
-      venue: "Draper Startup House, Rajiv gandhi Nagar",
-      location: "Gachibowli",
-      registerLink: "https://lu.ma/jehijqln",
-      startColour: "#A8D7FF",
-      endColour: "#6171FF",
-    },
-    {
-      id: 8,
-      time: "7:30 PM",
-      logo: swiftKozhikodeLogo,
-      chapterName: "Swift Kozhikode",
-      venue: "Kerala Startup Mission, 1650D, Palazhi, Kozhikode",
-      location: "Pantheeramkavu",
-      registerLink: "https://lu.ma/wvgrqd6p",
-      startColour: "#FFC677",
-      endColour: "#FF9500",
-    },
-  ];
-
   return (
     <div id="register" className="flex flex-col items-center justify-center">
       <div className="h-24" />
@@ -110,10 +13,13 @@ const RegisterNow = () => {
         Seats are limited—save yours today!
       </h4>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 md:gap-6 lg:gap-8 w-full max-w-6xl mt-8 px-8 lg:px-4">
-        {swiftEvents.map((event) => (
+        {cityEvents.map((event) => (
           <div
             key={event.id}
-            className={`aspect-square rounded-3xl bg-gradient-to-b from-[${event.startColour}] to-[${event.endColour}] shadow max-h-[265px] w-full transform transition-transform hover:scale-[1.02] hover:shadow-lg`}
+            className="aspect-square rounded-3xl shadow max-h-[265px] w-full transform transition-transform hover:scale-[1.02] hover:shadow-lg"
+            style={{
+              backgroundImage: `linear-gradient(180deg, ${event.gradient.from} 0%, ${event.gradient.to} 100%)`,
+            }}
           >
             <div className="flex flex-col items-start justify-center gap-3 p-6">
               <div className="text-white font-medium bg-black/80 px-3 py-1 rounded-md text-xs">
@@ -147,17 +53,12 @@ const RegisterNow = () => {
                   />
                   {event.location}
                 </div>
-                <button
-                  onClick={(e) => {
-                    e.preventDefault();
-                    if (event.registerLink !== "#") {
-                      window.open(event.registerLink, "_blank");
-                    }
-                  }}
+                <Link
+                  to={`/${event.slug}`}
                   className="rounded-lg bg-[#2A282F]/80 font-sans font-medium p-2 px-3 text-sm"
                 >
                   Register Now
-                </button>
+                </Link>
               </div>
             </div>
           </div>

--- a/src/data/city-events.ts
+++ b/src/data/city-events.ts
@@ -1,0 +1,35 @@
+import { ahmedabadEvent } from "./city-events/ahmedabad";
+import { bangaloreEvent } from "./city-events/bangalore";
+import { chennaiEvent } from "./city-events/chennai";
+import { delhiEvent } from "./city-events/delhi";
+import { hyderabadEvent } from "./city-events/hyderabad";
+import { kozhikodeEvent } from "./city-events/kozhikode";
+import { mumbaiEvent } from "./city-events/mumbai";
+import { suratEvent } from "./city-events/surat";
+import type { CityEvent } from "./city-events/types";
+
+export type { CityEvent } from "./city-events/types";
+
+export const cityEvents: CityEvent[] = [
+  bangaloreEvent,
+  mumbaiEvent,
+  ahmedabadEvent,
+  suratEvent,
+  chennaiEvent,
+  delhiEvent,
+  hyderabadEvent,
+  kozhikodeEvent,
+];
+
+export const getCityEventBySlug = (slug?: string) => {
+  if (!slug) {
+    return undefined;
+  }
+
+  const normalizedSlug = slug.trim().toLowerCase();
+
+  return cityEvents.find(
+    (event) =>
+      event.slug === normalizedSlug || event.aliases.includes(normalizedSlug)
+  );
+};

--- a/src/data/city-events/ahmedabad.ts
+++ b/src/data/city-events/ahmedabad.ts
@@ -1,0 +1,67 @@
+import swiftAhmedabadLogo from "../../assets/2025/organisers/swift-ahmedabad.svg";
+import sevenSpanLogo from "../../assets/2025/sponsors/7Span.svg";
+import { makeDescription } from "./helpers";
+import type { CityEvent } from "./types";
+
+export const ahmedabadEvent: CityEvent = {
+  id: 3,
+  slug: "ahmedabad",
+  aliases: [],
+  city: "Ahmedabad",
+  chapterName: "Swift Ahmedabad",
+  date: "June 9, 2025",
+  time: "9:00 PM",
+  startDate: "2025-06-09T21:00:00+05:30",
+  endDate: "2025-06-10T00:30:00+05:30",
+  logo: swiftAhmedabadLogo,
+  venue: "7Span, 201, Isquare Corporate Park",
+  address: "7Span, 201, Isquare Corporate Park, Sola, Ahmedabad",
+  structuredAddress: {
+    streetAddress: "7Span, 201, Isquare Corporate Park, Sola",
+    addressLocality: "Ahmedabad",
+    addressRegion: "Gujarat",
+    addressCountry: "IN",
+  },
+  location: "Sola",
+  lumaUrl: "https://lu.ma/kne1yfpm",
+  mapUrl:
+    "https://www.google.com/maps/search/?api=1&query=7Span%20Isquare%20Corporate%20Park%20Sola%20Ahmedabad",
+  sponsorName: "7Span",
+  sponsorLogo: sevenSpanLogo,
+  gradient: {
+    from: "#DE9CFF",
+    to: "#AF52DE",
+  },
+  description: makeDescription("Swift Ahmedabad", "7Span", "Ahmedabad"),
+  highlights: [
+    "Hosted with Swift Ahmedabad",
+    "Venue support from 7Span",
+    "Free registration through Luma",
+  ],
+  agenda: [
+    {
+      time: "9:00 PM",
+      title: "Doors open at 7Span",
+      description:
+        "Check in, meet local developers, and settle in before the keynote starts.",
+    },
+    {
+      time: "9:30 PM",
+      title: "Ahmedabad community welcome",
+      description:
+        "A short organizer welcome and community catch-up before the livestream.",
+    },
+    {
+      time: "10:30 PM",
+      title: "WWDC keynote watch",
+      description:
+        "Watch Apple's keynote live with Swift Ahmedabad and fellow Apple platform developers.",
+    },
+    {
+      time: "After keynote",
+      title: "Post-keynote discussion",
+      description:
+        "Break down the announcements and share thoughts on new platform updates.",
+    },
+  ],
+};

--- a/src/data/city-events/bangalore.ts
+++ b/src/data/city-events/bangalore.ts
@@ -1,0 +1,67 @@
+import swiftBengaluruLogo from "../../assets/2025/organisers/swift-bengaluru.png";
+import swiggyLogo from "../../assets/2025/sponsors/swiggy.png";
+import { makeDescription } from "./helpers";
+import type { CityEvent } from "./types";
+
+export const bangaloreEvent: CityEvent = {
+  id: 1,
+  slug: "bangalore",
+  aliases: ["bengaluru"],
+  city: "Bengaluru",
+  chapterName: "Swift Bengaluru",
+  date: "June 9, 2025",
+  time: "7:00 PM",
+  startDate: "2025-06-09T19:00:00+05:30",
+  endDate: "2025-06-10T00:30:00+05:30",
+  logo: swiftBengaluruLogo,
+  venue: "Swiggy HO, Ground Floor, Embassy TechVillage",
+  address: "Swiggy HO, Ground Floor, Embassy TechVillage, Varthur, Bengaluru",
+  structuredAddress: {
+    streetAddress: "Swiggy HO, Ground Floor, Embassy TechVillage, Varthur",
+    addressLocality: "Bengaluru",
+    addressRegion: "Karnataka",
+    addressCountry: "IN",
+  },
+  location: "Varthur",
+  lumaUrl: "https://lu.ma/9mfibs65",
+  mapUrl:
+    "https://www.google.com/maps/search/?api=1&query=Swiggy%20HO%20Embassy%20TechVillage%20Varthur%20Bengaluru",
+  sponsorName: "Swiggy",
+  sponsorLogo: swiggyLogo,
+  gradient: {
+    from: "#FFC677",
+    to: "#FF9500",
+  },
+  description: makeDescription("Swift Bengaluru", "Swiggy HO", "Bengaluru"),
+  highlights: [
+    "Hosted with Swift Bengaluru",
+    "Venue support from Swiggy",
+    "Free registration through Luma",
+  ],
+  agenda: [
+    {
+      time: "7:00 PM",
+      title: "Doors open at Swiggy",
+      description:
+        "Check in, settle into the venue, and meet the Bengaluru Swift community.",
+    },
+    {
+      time: "7:45 PM",
+      title: "Community introductions",
+      description:
+        "A quick welcome from the organizers before the keynote watch begins.",
+    },
+    {
+      time: "10:30 PM",
+      title: "WWDC keynote watch",
+      description:
+        "Watch Apple's announcements live with developers from across Bengaluru.",
+    },
+    {
+      time: "After keynote",
+      title: "Discussion and networking",
+      description:
+        "Swap reactions, API notes, and ideas for what to build next.",
+    },
+  ],
+};

--- a/src/data/city-events/chennai.ts
+++ b/src/data/city-events/chennai.ts
@@ -1,0 +1,67 @@
+import swiftChennaiLogo from "../../assets/2025/organisers/swift-chennai.png";
+import kissflowLogo from "../../assets/2025/sponsors/kissflow.png";
+import { makeDescription } from "./helpers";
+import type { CityEvent } from "./types";
+
+export const chennaiEvent: CityEvent = {
+  id: 5,
+  slug: "chennai",
+  aliases: [],
+  city: "Chennai",
+  chapterName: "Swift Chennai",
+  date: "June 9, 2025",
+  time: "8:00 PM",
+  startDate: "2025-06-09T20:00:00+05:30",
+  endDate: "2025-06-10T00:30:00+05:30",
+  logo: swiftChennaiLogo,
+  venue: "Kissflow, No. 5, Tower-B, 10th Floor",
+  address: "Kissflow, No. 5, Tower-B, 10th Floor, Perungudi, Chennai",
+  structuredAddress: {
+    streetAddress: "Kissflow, No. 5, Tower-B, 10th Floor, Perungudi",
+    addressLocality: "Chennai",
+    addressRegion: "Tamil Nadu",
+    addressCountry: "IN",
+  },
+  location: "Perungudi",
+  lumaUrl: "https://lu.ma/9engu1qy",
+  mapUrl:
+    "https://www.google.com/maps/search/?api=1&query=Kissflow%20Tower-B%2010th%20Floor%20Perungudi%20Chennai",
+  sponsorName: "Kissflow",
+  sponsorLogo: kissflowLogo,
+  gradient: {
+    from: "#A8D7FF",
+    to: "#6171FF",
+  },
+  description: makeDescription("Swift Chennai", "Kissflow", "Chennai"),
+  highlights: [
+    "Hosted with Swift Chennai",
+    "Venue support from Kissflow",
+    "Free registration through Luma",
+  ],
+  agenda: [
+    {
+      time: "8:00 PM",
+      title: "Arrival at Kissflow",
+      description:
+        "Check in, meet the Swift Chennai organizers, and get settled for the evening.",
+    },
+    {
+      time: "8:45 PM",
+      title: "Chennai community catch-up",
+      description:
+        "Connect with local Apple platform developers before the keynote stream begins.",
+    },
+    {
+      time: "10:30 PM",
+      title: "WWDC keynote watch",
+      description:
+        "Watch Apple's keynote live with Swift Chennai and follow the announcements together.",
+    },
+    {
+      time: "After keynote",
+      title: "Discussion and networking",
+      description:
+        "Share reactions, talk through new APIs, and keep the community conversations going.",
+    },
+  ],
+};

--- a/src/data/city-events/delhi.ts
+++ b/src/data/city-events/delhi.ts
@@ -1,0 +1,67 @@
+import swiftDelhiLogo from "../../assets/2025/organisers/swift-delhi.jpeg";
+import ixigoLogo from "../../assets/2025/sponsors/ixigo.png";
+import { makeDescription } from "./helpers";
+import type { CityEvent } from "./types";
+
+export const delhiEvent: CityEvent = {
+  id: 6,
+  slug: "delhi",
+  aliases: [],
+  city: "Delhi NCR",
+  chapterName: "Swift Delhi",
+  date: "June 9, 2025",
+  time: "9:00 PM",
+  startDate: "2025-06-09T21:00:00+05:30",
+  endDate: "2025-06-10T00:30:00+05:30",
+  logo: swiftDelhiLogo,
+  venue: "Ixigo Office, 2nd Floor, Veritas Building",
+  address: "Ixigo Office, 2nd Floor, Veritas Building, Gurugram",
+  structuredAddress: {
+    streetAddress: "Ixigo Office, 2nd Floor, Veritas Building",
+    addressLocality: "Gurugram",
+    addressRegion: "Haryana",
+    addressCountry: "IN",
+  },
+  location: "Gurugram",
+  lumaUrl: "https://lu.ma/pry2tx7d",
+  mapUrl:
+    "https://www.google.com/maps/search/?api=1&query=Ixigo%20Office%20Veritas%20Building%20Gurugram",
+  sponsorName: "ixigo",
+  sponsorLogo: ixigoLogo,
+  gradient: {
+    from: "#A8D7FF",
+    to: "#6171FF",
+  },
+  description: makeDescription("Swift Delhi", "Ixigo Office", "Delhi NCR"),
+  highlights: [
+    "Hosted with Swift Delhi",
+    "Venue support from ixigo",
+    "Free registration through Luma",
+  ],
+  agenda: [
+    {
+      time: "9:00 PM",
+      title: "Doors open at ixigo",
+      description:
+        "Arrive at the Gurugram venue, check in, and meet the Delhi NCR community.",
+    },
+    {
+      time: "9:30 PM",
+      title: "Delhi NCR community welcome",
+      description:
+        "A short welcome from the organizers before everyone joins the live keynote.",
+    },
+    {
+      time: "10:30 PM",
+      title: "WWDC keynote watch",
+      description:
+        "Watch Apple's keynote live with Swift Delhi and other Apple platform builders.",
+    },
+    {
+      time: "After keynote",
+      title: "Post-keynote reactions",
+      description:
+        "Discuss the announcements, share first impressions, and compare notes with the room.",
+    },
+  ],
+};

--- a/src/data/city-events/helpers.ts
+++ b/src/data/city-events/helpers.ts
@@ -1,0 +1,6 @@
+export const makeDescription = (
+  chapterName: string,
+  venue: string,
+  city: string
+) =>
+  `Join ${chapterName} at ${venue} for the WWDC 2025 Watch Party Around India. Watch the keynote with developers in ${city}, meet the local community, and keep the conversation going after the announcements.`;

--- a/src/data/city-events/hyderabad.ts
+++ b/src/data/city-events/hyderabad.ts
@@ -1,0 +1,71 @@
+import swiftHyderabadLogo from "../../assets/2025/organisers/swift-hyderabad.svg";
+import draperStartUpHouseLogo from "../../assets/2025/sponsors/draper.svg";
+import { makeDescription } from "./helpers";
+import type { CityEvent } from "./types";
+
+export const hyderabadEvent: CityEvent = {
+  id: 7,
+  slug: "hyderabad",
+  aliases: ["hyderbad"],
+  city: "Hyderabad",
+  chapterName: "Swift Hyderabad",
+  date: "June 9, 2025",
+  time: "7:00 PM",
+  startDate: "2025-06-09T19:00:00+05:30",
+  endDate: "2025-06-10T00:30:00+05:30",
+  logo: swiftHyderabadLogo,
+  venue: "Draper Startup House, Rajiv Gandhi Nagar",
+  address: "Draper Startup House, Rajiv Gandhi Nagar, Gachibowli, Hyderabad",
+  structuredAddress: {
+    streetAddress: "Draper Startup House, Rajiv Gandhi Nagar, Gachibowli",
+    addressLocality: "Hyderabad",
+    addressRegion: "Telangana",
+    addressCountry: "IN",
+  },
+  location: "Gachibowli",
+  lumaUrl: "https://lu.ma/jehijqln",
+  mapUrl:
+    "https://www.google.com/maps/search/?api=1&query=Draper%20Startup%20House%20Gachibowli%20Hyderabad",
+  sponsorName: "Draper Startup House",
+  sponsorLogo: draperStartUpHouseLogo,
+  gradient: {
+    from: "#A8D7FF",
+    to: "#6171FF",
+  },
+  description: makeDescription(
+    "Swift Hyderabad",
+    "Draper Startup House",
+    "Hyderabad"
+  ),
+  highlights: [
+    "Hosted with Swift Hyderabad",
+    "Venue support from Draper Startup House",
+    "Free registration through Luma",
+  ],
+  agenda: [
+    {
+      time: "7:00 PM",
+      title: "Doors open at Draper Startup House",
+      description:
+        "Check in, meet the Hyderabad organizers, and settle in at the Gachibowli venue.",
+    },
+    {
+      time: "7:45 PM",
+      title: "Hyderabad community mixer",
+      description:
+        "Spend time with local iOS, macOS, watchOS, and design folks before the keynote.",
+    },
+    {
+      time: "10:30 PM",
+      title: "WWDC keynote watch",
+      description:
+        "Watch Apple's keynote live with Swift Hyderabad and react to the announcements together.",
+    },
+    {
+      time: "After keynote",
+      title: "Design and developer discussion",
+      description:
+        "Talk through the updates, new APIs, and what the Hyderabad community wants to explore next.",
+    },
+  ],
+};

--- a/src/data/city-events/kozhikode.ts
+++ b/src/data/city-events/kozhikode.ts
@@ -1,0 +1,71 @@
+import swiftKozhikodeLogo from "../../assets/2025/organisers/swift-kozhikode.svg";
+import keralaStartupMissionLogo from "../../assets/2025/sponsors/kerala-startup-mission.svg";
+import { makeDescription } from "./helpers";
+import type { CityEvent } from "./types";
+
+export const kozhikodeEvent: CityEvent = {
+  id: 8,
+  slug: "kozhikode",
+  aliases: [],
+  city: "Kozhikode",
+  chapterName: "Swift Kozhikode",
+  date: "June 9, 2025",
+  time: "7:30 PM",
+  startDate: "2025-06-09T19:30:00+05:30",
+  endDate: "2025-06-10T00:30:00+05:30",
+  logo: swiftKozhikodeLogo,
+  venue: "Kerala Startup Mission, 1650D, Palazhi",
+  address: "Kerala Startup Mission, 1650D, Palazhi, Pantheeramkavu, Kozhikode",
+  structuredAddress: {
+    streetAddress: "Kerala Startup Mission, 1650D, Palazhi, Pantheeramkavu",
+    addressLocality: "Kozhikode",
+    addressRegion: "Kerala",
+    addressCountry: "IN",
+  },
+  location: "Pantheeramkavu",
+  lumaUrl: "https://lu.ma/wvgrqd6p",
+  mapUrl:
+    "https://www.google.com/maps/search/?api=1&query=Kerala%20Startup%20Mission%20Palazhi%20Pantheeramkavu%20Kozhikode",
+  sponsorName: "Kerala Startup Mission",
+  sponsorLogo: keralaStartupMissionLogo,
+  gradient: {
+    from: "#FFC677",
+    to: "#FF9500",
+  },
+  description: makeDescription(
+    "Swift Kozhikode",
+    "Kerala Startup Mission",
+    "Kozhikode"
+  ),
+  highlights: [
+    "Hosted with Swift Kozhikode",
+    "Venue support from Kerala Startup Mission",
+    "Free registration through Luma",
+  ],
+  agenda: [
+    {
+      time: "7:30 PM",
+      title: "Check-in at Kerala Startup Mission",
+      description:
+        "Arrive, meet the Kozhikode organizers, and connect with the local community.",
+    },
+    {
+      time: "8:15 PM",
+      title: "Kozhikode community networking",
+      description:
+        "Meet fellow Apple platform developers and share what you are hoping to see at WWDC.",
+    },
+    {
+      time: "10:30 PM",
+      title: "WWDC keynote watch",
+      description:
+        "Watch Apple's keynote live with Swift Kozhikode and follow the announcements together.",
+    },
+    {
+      time: "After keynote",
+      title: "Takeaways and community wrap-up",
+      description:
+        "Share first reactions, useful links, and ideas for future community sessions.",
+    },
+  ],
+};

--- a/src/data/city-events/mumbai.ts
+++ b/src/data/city-events/mumbai.ts
@@ -1,0 +1,67 @@
+import swiftMumbaiLogo from "../../assets/2025/organisers/swift-mumbai.png";
+import bookMyShowLogo from "../../assets/2025/sponsors/bookmyshow.png";
+import { makeDescription } from "./helpers";
+import type { CityEvent } from "./types";
+
+export const mumbaiEvent: CityEvent = {
+  id: 2,
+  slug: "mumbai",
+  aliases: [],
+  city: "Mumbai",
+  chapterName: "Swift Mumbai",
+  date: "June 9, 2025",
+  time: "7:30 PM",
+  startDate: "2025-06-09T19:30:00+05:30",
+  endDate: "2025-06-10T00:30:00+05:30",
+  logo: swiftMumbaiLogo,
+  venue: "BookMyShow Office, Empressa 14",
+  address: "BookMyShow Office, Empressa 14, Andheri East, Mumbai",
+  structuredAddress: {
+    streetAddress: "BookMyShow Office, Empressa 14, Andheri East",
+    addressLocality: "Mumbai",
+    addressRegion: "Maharashtra",
+    addressCountry: "IN",
+  },
+  location: "Andheri East",
+  lumaUrl: "https://lu.ma/cbn8zy6m",
+  mapUrl:
+    "https://www.google.com/maps/search/?api=1&query=BookMyShow%20Office%20Empressa%2014%20Andheri%20East%20Mumbai",
+  sponsorName: "BookMyShow",
+  sponsorLogo: bookMyShowLogo,
+  gradient: {
+    from: "#A8D7FF",
+    to: "#6171FF",
+  },
+  description: makeDescription("Swift Mumbai", "BookMyShow Office", "Mumbai"),
+  highlights: [
+    "Hosted with Swift Mumbai",
+    "Venue support from BookMyShow",
+    "Free registration through Luma",
+  ],
+  agenda: [
+    {
+      time: "7:30 PM",
+      title: "Arrival and check-in",
+      description:
+        "Meet the Swift Mumbai organizers and find your group for the evening.",
+    },
+    {
+      time: "8:15 PM",
+      title: "Pre-keynote conversations",
+      description:
+        "Talk through predictions, expectations, and favorite announcements from past WWDCs.",
+    },
+    {
+      time: "10:30 PM",
+      title: "WWDC keynote watch",
+      description:
+        "Watch the keynote live from the BookMyShow office with the Mumbai community.",
+    },
+    {
+      time: "After keynote",
+      title: "Mumbai community wrap-up",
+      description:
+        "Discuss what matters most for app teams, indie developers, and designers.",
+    },
+  ],
+};

--- a/src/data/city-events/surat.ts
+++ b/src/data/city-events/surat.ts
@@ -1,0 +1,67 @@
+import swiftSuratLogo from "../../assets/2025/organisers/swift-surat.jpeg";
+import jbcodeappLogo from "../../assets/2025/sponsors/jbcodeapp.jpeg";
+import { makeDescription } from "./helpers";
+import type { CityEvent } from "./types";
+
+export const suratEvent: CityEvent = {
+  id: 4,
+  slug: "surat",
+  aliases: [],
+  city: "Surat",
+  chapterName: "Swift Surat",
+  date: "June 9, 2025",
+  time: "8:00 PM",
+  startDate: "2025-06-09T20:00:00+05:30",
+  endDate: "2025-06-10T00:30:00+05:30",
+  logo: swiftSuratLogo,
+  venue: "JBcodeapp, 536, 5, Square Point, M.V Circle",
+  address: "JBcodeapp, 536, 5, Square Point, M.V Circle, Dahin Nagar, Surat",
+  structuredAddress: {
+    streetAddress: "JBcodeapp, 536, 5, Square Point, M.V Circle, Dahin Nagar",
+    addressLocality: "Surat",
+    addressRegion: "Gujarat",
+    addressCountry: "IN",
+  },
+  location: "Dahin Nagar",
+  lumaUrl: "https://lu.ma/j41uncut",
+  mapUrl:
+    "https://www.google.com/maps/search/?api=1&query=JBcodeapp%20Square%20Point%20M.V%20Circle%20Dahin%20Nagar%20Surat",
+  sponsorName: "JBCodeapp",
+  sponsorLogo: jbcodeappLogo,
+  gradient: {
+    from: "#BB5BF3",
+    to: "#6900EE",
+  },
+  description: makeDescription("Swift Surat", "JBcodeapp", "Surat"),
+  highlights: [
+    "Hosted with Swift Surat",
+    "Venue support from JBCodeapp",
+    "Free registration through Luma",
+  ],
+  agenda: [
+    {
+      time: "8:00 PM",
+      title: "Check-in at JBcodeapp",
+      description:
+        "Arrive, meet the Surat organizers, and connect with local developers.",
+    },
+    {
+      time: "8:45 PM",
+      title: "Community networking",
+      description:
+        "Spend time with other Apple platform builders before the keynote stream.",
+    },
+    {
+      time: "10:30 PM",
+      title: "WWDC keynote watch",
+      description:
+        "Watch the keynote live with Swift Surat and react to the announcements together.",
+    },
+    {
+      time: "After keynote",
+      title: "Ideas and takeaways",
+      description:
+        "Discuss new APIs, tools, and what the Surat community wants to explore next.",
+    },
+  ],
+};

--- a/src/data/city-events/types.ts
+++ b/src/data/city-events/types.ts
@@ -1,0 +1,38 @@
+export interface CityEventAgendaItem {
+  time: string;
+  title: string;
+  description: string;
+}
+
+export interface CityEvent {
+  id: number;
+  slug: string;
+  aliases: string[];
+  city: string;
+  chapterName: string;
+  date: string;
+  time: string;
+  startDate: string;
+  endDate: string;
+  logo: string;
+  venue: string;
+  address: string;
+  structuredAddress: {
+    streetAddress: string;
+    addressLocality: string;
+    addressRegion: string;
+    addressCountry: string;
+  };
+  location: string;
+  lumaUrl: string;
+  mapUrl: string;
+  sponsorName: string;
+  sponsorLogo: string;
+  gradient: {
+    from: string;
+    to: string;
+  };
+  description: string;
+  highlights: string[];
+  agenda: CityEventAgendaItem[];
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createHashRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, Navigate, RouterProvider } from "react-router-dom";
 
 import App from "./App.tsx";
 import App2024 from "./2024/App.tsx";
+import CityEventPage from "./components/city-event-page.tsx";
 
 import "./index.css";
 
-const router = createHashRouter([
+const router = createBrowserRouter([
   {
     path: "/",
     element: <App />,
@@ -15,6 +16,14 @@ const router = createHashRouter([
   {
     path: "/2024",
     element: <App2024 />,
+  },
+  {
+    path: "/:citySlug",
+    element: <CityEventPage />,
+  },
+  {
+    path: "*",
+    element: <Navigate to="/" replace />,
   },
 ]);
 


### PR DESCRIPTION
# PR: Add Clean City Event Pages With Per-City Data

Target branch: `main`

## Summary

This PR adds clean city-specific event pages for WWDC Watch Party Around India and moves city event content into structured, per-city TypeScript data files. Each city now owns its own agenda, Luma registration link, venue details, sponsor details, and Event schema data.

## What Changed

- Added clean city routes like `/hyderabad`, `/delhi`, `/bangalore`, `/mumbai`, `/ahmedabad`, `/surat`, `/chennai`, and `/kozhikode`.
- Added a reusable city event page for city-specific landing pages.
- Added per-city event data files under `src/data/city-events/`.
- Kept a stable city data export through `src/data/city-events.ts`.
- Added city-specific agendas so each city can have a different schedule.
- Added Event structured data JSON-LD for city pages.
- Updated homepage registration cards to route to the clean city pages.
- Fixed city page Register buttons so both links open the correct Luma event page for the active city.
- Added GitHub Pages fallback handling for clean browser routes.
- Added project README documentation for updating city pages, agendas, Luma links, and schema fields.

## City Data Structure

Each city has its own file:

- `src/data/city-events/ahmedabad.ts`
- `src/data/city-events/bangalore.ts`
- `src/data/city-events/chennai.ts`
- `src/data/city-events/delhi.ts`
- `src/data/city-events/hyderabad.ts`
- `src/data/city-events/kozhikode.ts`
- `src/data/city-events/mumbai.ts`
- `src/data/city-events/surat.ts`

The root `src/data/city-events.ts` file imports these city blocks and exports `cityEvents` plus `getCityEventBySlug`.

## Notes

- Luma is linked directly instead of embedded because Luma event pages block iframe rendering with frame protection headers.
- `/hyderbad` is supported as an alias and redirects to `/hyderabad`.
- Structured data follows Google's Event schema guidance and is generated from the same city data used by the UI.

## Testing

- `npm run lint`
- `npm run build`
- Verified `/hyderabad`, `/chennai`, `/delhi`, `/kozhikode`, and `/hyderbad` with headless Chrome.
- Verified Hyderabad renders Event JSON-LD.
- Verified both Hyderabad Register buttons point to `https://lu.ma/jehijqln`.

## Review Checklist

- Confirm each city has the correct Luma URL.
- Confirm each city agenda is final or marked for organizer review.
- Confirm venue addresses and schema dates are accurate.
- Confirm clean URLs work after deployment to GitHub Pages.
