### PR TITLE
fix: guard react-tweet entities to unbreak prod render

### DIFF
--- a/src/components/testimonials.tsx
+++ b/src/components/testimonials.tsx
@@ -1,4 +1,29 @@
-import { Tweet } from "react-tweet";
+import {
+  EmbeddedTweet,
+  TweetNotFound,
+  TweetSkeleton,
+  useTweet,
+} from "react-tweet";
+
+// Twitter's syndication API now omits empty entity arrays (hashtags/urls/
+// user_mentions/symbols), which crashes react-tweet@3.3.0's enrichTweet.
+// Default them back to [] before handing the data to EmbeddedTweet.
+const SafeTweet = ({ id }: { id: string }) => {
+  const { data, error, isLoading } = useTweet(id);
+  if (isLoading) return <TweetSkeleton />;
+  if (error || !data) return <TweetNotFound error={error} />;
+  const tweet = {
+    ...data,
+    entities: {
+      ...data.entities,
+      hashtags: data.entities.hashtags ?? [],
+      urls: data.entities.urls ?? [],
+      user_mentions: data.entities.user_mentions ?? [],
+      symbols: data.entities.symbols ?? [],
+    },
+  };
+  return <EmbeddedTweet tweet={tweet} />;
+};
 
 const Testimonials = () => {
   const tweets = [
@@ -24,7 +49,7 @@ const Testimonials = () => {
       <div className="columns-1 sm:columns-2 lg:columns-3 gap-4 w-full max-w-7xl mt-8 mx-auto px-3 space-y-4">
         {tweets.map((tweet) => (
           <div key={tweet} className="light break-inside-avoid mb-4 px-1">
-            <Tweet id={tweet} />
+            <SafeTweet id={tweet} />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Production is crashing with `TypeError: n is not iterable` on every page load. Root cause is **not** routing — React Router is just the nearest error boundary that catches it.
- Twitter's syndication API recently started **omitting** empty entity arrays (`hashtags` / `urls` / `user_mentions` / `symbols`) from tweet payloads. `react-tweet@3.3.x`'s `enrichTweet` does `for (const r of n)` on each bucket without a guard, so any missing bucket throws.
- This PR wraps each `<Tweet>` with a `SafeTweet` that uses `useTweet` + `EmbeddedTweet`, defaulting every entity array to `[]` before render. Surgical — only `src/components/testimonials.tsx` changes.

## Why this only ships the unbreak
The fix already exists on `dev` but is bundled there with the 2026 content refresh (Bengaluru / Nagpur / Pune / Chennai updates, team roster, etc.). This branch is cut directly from `origin/main` and applies the same defaulting pattern over main's original 5 tweet IDs only — none of the 2026 content comes along.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — builds successfully (Vite, 1.08s)
- [ ] After merge, verify https://watchpartyaroundindia.com loads without the `n is not iterable` error in the console
- [ ] Confirm all 5 testimonial tweets render (or show TweetNotFound gracefully if syndication returns nothing)

## Follow-ups (separate PRs)
- Merge `dev` → `main` when ready to ship the 2026 content (Bengaluru details, Chennai update, new city pages).