### PR TITLE
fix: unblock deploy by resolving TypeScript build errors

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -35,7 +35,7 @@ const Navbar = () => {
         <Link to="/">
           <img
             src={wwdcLogo}
-            srcset={logoSrcSet}
+            srcSet={logoSrcSet}
             alt="WWDC 2026 logo"
             className="w-24 h-9 md:w-32 md:h-11 lg:w-[148px] lg:h-[54px]"
           />
@@ -96,7 +96,7 @@ const Navbar = () => {
         {navItems.map((item) =>
           <Link
             key={item.id}
-            to={item.section}
+            to={item.link}
             className="hover:underline hover:decoration-[#FFC9F0] hover:underline-offset-1 hover:[text-decoration-thickness:5px] cursor-pointer text-xl lg:text-2xl"
             onClick={() => setMenuOpen(false)}
           >

--- a/src/components/sponsors.tsx
+++ b/src/components/sponsors.tsx
@@ -1,6 +1,5 @@
 import { FC } from "react";
 import sponsorsRound from "../assets/2025/sponsors-round.svg";
-import sevenSpanlogo from "../assets/2025/sponsors/7Span.svg";
 import atlasLogo from "../assets/2025/sponsors/atlas.svg";
 import ixigoLogo from "../assets/2025/sponsors/ixigo.png";
 import keralaStartupMissionLogo from "../assets/2025/sponsors/kerala-startup-mission.svg";

--- a/src/data/city-events/nagpur.ts
+++ b/src/data/city-events/nagpur.ts
@@ -17,6 +17,7 @@ export const nagpurEvent: CityEvent = {
   venue: "Venue to be announced",
   address: "Nagpur, Maharashtra",
   structuredAddress: {
+    streetAddress: "",
     addressLocality: "Nagpur",
     addressRegion: "Maharashtra",
     addressCountry: "IN",


### PR DESCRIPTION
## Summary
The `Deploy` workflow on `main` has been failing since PR #23 because `tsc && vite build` rejects four type errors. This PR fixes them so the gh-pages deploy can proceed.

- `src/components/navbar.tsx` — `srcset` → `srcSet` (React JSX casing); `item.section` → `item.link` (matches the `navItems` shape declared in the same file)
- `src/components/sponsors.tsx` — drop unused `sevenSpanlogo` import (7Span was removed from the venue sponsor list)
- `src/data/city-events/nagpur.ts` — add the required `streetAddress` field on `structuredAddress` (empty string; venue still TBA)

Failing run: https://github.com/WatchPartyAroundIndia/watchpartyaroundindia.github.io/actions/runs/26464646635

Branched directly off `origin/main` (rather than PR'ing `dev`) to avoid reverting #22 (CNAME relocation) and #24 (vite dep bump), which exist on main but not on dev.

## Test plan
- [x] \`bunx tsc --noEmit\` passes locally
- [x] \`bun run build\` succeeds locally (built in 1.16s)
- [ ] GitHub Actions \`Deploy\` workflow succeeds on merge